### PR TITLE
Features/lazy quantifiers

### DIFF
--- a/dfalex.sln.DotSettings
+++ b/dfalex.sln.DotSettings
@@ -1,0 +1,13 @@
+﻿<wpf:ResourceDictionary xml:space="preserve"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:s="clr-namespace:System;assembly=mscorlib"
+    xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml"
+    xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=Catenate/@EntryIndexedValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=Matchables/@EntryIndexedValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=automata/@EntryIndexedValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=Magne/@EntryIndexedValue">True</s:Boolean>
+    <s:Boolean x:Key="/Default/UserDictionary/Words/=Timmermans/@EntryIndexedValue">True</s:Boolean>
+
+</wpf:ResourceDictionary>

--- a/dfalex.tests/DfaTests.cs
+++ b/dfalex.tests/DfaTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CodeHive.DfaLex.Tests
+{
+    public class DfaTests : TestBase
+    {
+        public DfaTests(ITestOutputHelper helper)
+            : base(helper)
+        { }
+
+        [Fact]
+        public void TestIt()
+        {
+            CheckDfa(Pattern.Regex("(a*b|d)+c?c?c?"), "");
+        }
+
+        private void CheckDfa(IMatchable regex, string resourceSection)
+        {
+            var nfa = new Nfa<int>();
+            var startStates = new[] {AddToNfa(nfa, regex, 1), AddToNfa(nfa, Pattern.Regex("a*(b|c)d+"), 2)};
+
+            var rawDfa = new DfaFromNfa<int>(nfa, startStates, null).GetDfa();
+            var minimalDfa = new DfaMinimizer<int>(rawDfa).GetMinimizedDfa();
+            PrintDot(minimalDfa);
+            // serializableDfa = new SerializableDfa<TResult>(minimalDfa);
+
+//            CheckNfa(nfa, state, $"NfaTests.out.txt#{resourceSection}", true);
+        }
+
+        private int AddToNfa<T>(Nfa<T> nfa, IMatchable pattern, T match)
+        {
+            var start = nfa.AddState();
+            var accept = nfa.AddState(match);
+
+            var state = pattern.AddToNfa(nfa, accept);
+            nfa.AddEpsilon(start, state);
+
+            return start;
+        }
+    }
+}

--- a/dfalex.tests/Labeled.cs
+++ b/dfalex.tests/Labeled.cs
@@ -1,0 +1,24 @@
+namespace CodeHive.DfaLex.Tests
+{
+    public class Labeled<T>
+    {
+        public Labeled(T data, string label)
+        {
+            Data = data;
+            Label = label;
+        }
+
+        public T Data { get; }
+        public string Label { get; }
+
+        public override string ToString()
+        {
+            return Label;
+        }
+    }
+
+    public static class LabeledExtensions
+    {
+        public static Labeled<T> Labeled<T>(this T source, string label) => new Labeled<T>(source, label);
+    }
+}

--- a/dfalex.tests/NfaTests.cs
+++ b/dfalex.tests/NfaTests.cs
@@ -6,19 +6,23 @@ namespace CodeHive.DfaLex.Tests
 {
     public class NfaTests : TestBase
     {
-        public NfaTests(ITestOutputHelper helper) : base(helper)
+        public NfaTests(ITestOutputHelper helper)
+            : base(helper)
         { }
 
         public static IEnumerable<object[]> GetMatchables()
         {
             static object[] Make(string section, string regex, IMatchable matchable, bool reversed = false) =>
-                new object[] {(section, regex, matchable, reversed).Labeled($"{section}: {regex}")};
+                new object[] { (section, regex, matchable, reversed).Labeled($"{section}: {regex}") };
 
-            yield return Make("Catenate",  "ab",    Pattern.Match("a").Then("b"), true);
-            yield return Make("Alternate", "a|b|c", Pattern.AnyOf("a", "b", "c"));
-            yield return Make("Question",  "a?",    Pattern.Maybe("a"));
-            yield return Make("Star",      "a*",    Pattern.MaybeRepeat("a"));
-            yield return Make("Plus",      "a+",    Pattern.Repeat("a"));
+            yield return Make("Catenate",      "ab",    Pattern.Match("a").Then("b"), true);
+            yield return Make("Alternate",     "a|b|c", Pattern.AnyOf("a", "b", "c"));
+            yield return Make("Question",      "a?",    Pattern.Maybe("a"));
+            yield return Make("Question Lazy", null,    Pattern.MaybeLazy("a"));
+            yield return Make("Star",          "a*",    Pattern.MaybeRepeat("a"));
+            yield return Make("Star Lazy",     null,    Pattern.MaybeRepeatLazy("a"));
+            yield return Make("Plus",          "a+",    Pattern.Repeat("a"));
+            yield return Make("Plus Lazy",     null,    Pattern.RepeatLazy("a"));
         }
 
         [Theory]
@@ -32,7 +36,10 @@ namespace CodeHive.DfaLex.Tests
         [MemberData(nameof(GetMatchables))]
         public void CheckRegex(Labeled<(string section, string regex, IMatchable _, bool reversed)> t)
         {
-            CheckNfa(Pattern.Regex(t.Data.regex), t.Data.section);
+            if (t.Data.regex != null)
+            {
+                CheckNfa(Pattern.Regex(t.Data.regex), t.Data.section);
+            }
         }
 
         [Theory]

--- a/dfalex.tests/NfaTests.cs
+++ b/dfalex.tests/NfaTests.cs
@@ -59,7 +59,7 @@ namespace CodeHive.DfaLex.Tests
             var state = regex.AddToNfa(nfa, accept);
             nfa.AddEpsilon(start, state);
 
-            CheckNfa(nfa, state, $"NfaTests.out.txt#{resourceSection}", true);
+            CheckNfa(nfa, state, $"NfaTests.out.txt#{resourceSection}");
         }
     }
 }

--- a/dfalex.tests/NfaTests.out.txt
+++ b/dfalex.tests/NfaTests.out.txt
@@ -43,6 +43,15 @@ S1:1
 S2
     a -> S1:1
 
+[Question Lazy]
+S0
+    ε -> S1:1
+   -ε -> S2
+S1:1
+    (done)
+S2
+    a -> S1:1
+
 [Star]
 S0
    -ε -> S1:1
@@ -53,7 +62,19 @@ S2
     a -> S3
 S3
    -ε -> S1:1
-    ε -> S2
+    ε -> S0
+
+[Star Lazy]
+S0
+    ε -> S1:1
+   -ε -> S2
+S1:1
+    (done)
+S2
+    a -> S3
+S3
+    ε -> S1:1
+    ε -> S0
 
 [Plus]
 S0
@@ -61,5 +82,14 @@ S0
 S1
    -ε -> S2:1
     ε -> S0
+S2:1
+    (done)
+
+[Plus Lazy]
+S0
+    a -> S1
+S1
+    ε -> S2:1
+   -ε -> S0
 S2:1
     (done)

--- a/dfalex.tests/NfaTests.out.txt
+++ b/dfalex.tests/NfaTests.out.txt
@@ -1,9 +1,65 @@
+[Catenate]
 S0
-    a -> b -> S1
-S1
-    c -> S2
-S2
-    ε -> S3:1
+    a -> b -> S1:1
+S1:1
+    (done)
+
+[Catenate Reversed]
+S0
+    b -> a -> S1:1
+S1:1
+    (done)
+
+[Alternate]
+S0
     ε -> S1
-S3:1
+    ε -> S2
+S1
+    c -> S3
+S2
+    ε -> S4
+    ε -> S5
+S3
+   -ε -> S6:1
+S4
+    b -> S7
+S5
+    a -> S8
+S6:1
+    (done)
+S7
+   -ε -> S9
+S8
+    ε -> S9
+S9
+    ε -> S6:1
+
+[Question]
+S0
+   -ε -> S1:1
+    ε -> S2
+S1:1
+    (done)
+S2
+    a -> S1:1
+
+[Star]
+S0
+   -ε -> S1:1
+    ε -> S2
+S1:1
+    (done)
+S2
+    a -> S3
+S3
+   -ε -> S1:1
+    ε -> S2
+
+[Plus]
+S0
+    a -> S1
+S1
+   -ε -> S2:1
+    ε -> S0
+S2:1
     (done)

--- a/dfalex.tests/PrettyPrinter.cs
+++ b/dfalex.tests/PrettyPrinter.cs
@@ -374,7 +374,7 @@ namespace CodeHive.DfaLex.Tests
 
             protected override void WriteEpsilon(TState state, TState target, bool lowPriority)
             {
-                Buf.AppendLine($"{Ctx.StateName(state, false)} -> {Ctx.StateName(target, false)} [label=\"{(lowPriority ? "-" : " ")}ε\"]");
+                Buf.AppendLine($"{Ctx.StateName(state, false)} -> {Ctx.StateName(target, false)} [label=\"{(lowPriority ? "-" : string.Empty)}ε\"]");
             }
 
             protected override void WriteTransition(TState state, TState target, char cMin, char cMax, bool lowPriority)
@@ -386,7 +386,7 @@ namespace CodeHive.DfaLex.Tests
                     label.Append('-').Append(PrintChar(cMax, true));
                 }
 
-                Buf.AppendLine($"{Ctx.StateName(state)} -> {Ctx.StateName(target, false)} [label=\"{(lowPriority ? "-" : " ")}{label}\"]");
+                Buf.AppendLine($"{Ctx.StateName(state)} -> {Ctx.StateName(target, false)} [label=\"{(lowPriority ? "-" : string.Empty)}{label}\"]");
             }
 
             public override string ToString()

--- a/dfalex.tests/RegexTest.cs
+++ b/dfalex.tests/RegexTest.cs
@@ -51,9 +51,19 @@ namespace CodeHive.DfaLex.Tests
             p2 = Pattern.Regex("A(C|D)*B");
             Check(p1, p2);
 
-            p1 = Pattern.Match("A").ThenMaybeRepeat(Pattern.AnyOf("C", "D")).Then("B");
-            p2 = Pattern.Regex("A(C|D)+?B");
+#pragma warning disable 618
+            p1 = Pattern.Match("A").ThenMaybe(Pattern.AnyOf("C", "D")).Then("B");
+            p2 = Pattern.Regex("A(C|D)??B", RegexOptions.Legacy);
             Check(p1, p2);
+
+            p1 = Pattern.Match("A").ThenMaybeRepeat(Pattern.AnyOf("C", "D")).Then("B");
+            p2 = Pattern.Regex("A(C|D)+?B", RegexOptions.Legacy);
+            Check(p1, p2);
+
+            p1 = Pattern.Match("A").ThenMaybeRepeat(Pattern.AnyOf("C", "D")).Then("B");
+            p2 = Pattern.Regex("A(C|D)*?B", RegexOptions.Legacy);
+            Check(p1, p2);
+#pragma warning restore 618
 
             p1 = Pattern.AnyOf(Pattern.Match("A").ThenMaybeRepeat("B"), Pattern.Match("C"));
             p2 = Pattern.Regex("AB*|C");

--- a/dfalex.tests/TestBase.cs
+++ b/dfalex.tests/TestBase.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -9,6 +11,13 @@ namespace CodeHive.DfaLex.Tests
 {
     public class TestBase
     {
+        private static readonly Regex ResourcePattern = new Regex(@"^(?<path>.+?)(?:#(?<section>.+))?$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        private static readonly Regex SectionPattern = new Regex(@"\s*^\[(?<section>.+?)\]\s+(?<content>[^[]*)",
+            System.Text.RegularExpressions.RegexOptions.Compiled | System.Text.RegularExpressions.RegexOptions.Multiline);
+
+        private static readonly IDictionary<string, string> Resources = new Dictionary<string, string>();
+
         private readonly ITestOutputHelper helper;
 
         protected TestBase(ITestOutputHelper helper)
@@ -79,7 +88,39 @@ namespace CodeHive.DfaLex.Tests
 
         protected string ReadResource(string resource)
         {
-            var type = GetType();
+            if (!Resources.TryGetValue(resource, out var result))
+            {
+                var match = ResourcePattern.Match(resource);
+                if (!match.Success)
+                {
+                    throw new ArgumentException(nameof(resource), $"Could not parse: {resource}");
+                }
+
+                var path = match.Groups["path"].Value;
+                var section = match.Groups["section"];
+                if (!Resources.TryGetValue(path, out result))
+                {
+                    result = ReadAssemblyResource(path);
+                    Resources[path] = result ?? throw new InvalidOperationException($"Could not find resource: {resource}");
+
+                    if (section.Success)
+                    {
+                        SplitInSections(result, path);
+                    }
+                }
+
+                if (section.Success && !Resources.TryGetValue(resource, out result))
+                {
+                    throw new InvalidOperationException($"Could not find section '{section.Value}' in resource: {path}");
+                }
+            }
+
+            return result;
+        }
+
+        private static string ReadAssemblyResource(string resource)
+        {
+            var type = typeof(TestBase);
             var assembly = type.GetTypeInfo().Assembly;
             var filename = type.Namespace + "." + resource;
 
@@ -91,6 +132,17 @@ namespace CodeHive.DfaLex.Tests
 
             using var reader = new StreamReader(stream);
             return reader.ReadToEnd();
+        }
+
+        private static void SplitInSections(string resource, string path)
+        {
+            var matches = SectionPattern.Matches(resource);
+            foreach (Match match in matches)
+            {
+                var section = match.Groups["section"].Value;
+                var content = match.Groups["content"].Value.Trim(' ', '\t', '\n', '\r') + "\n";
+                Resources.Add($"{path}#{section}", content);
+            }
         }
     }
 }

--- a/dfalex.tests/TestBase.cs
+++ b/dfalex.tests/TestBase.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using Xunit;
+using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace CodeHive.DfaLex.Tests
@@ -55,25 +55,30 @@ namespace CodeHive.DfaLex.Tests
         internal void CheckNfa<T>(Nfa<T> nfa, int start, string resource, bool doStdout = false)
         {
             var have = PrettyPrinter.Print(nfa, start);
-            if (doStdout)
-            {
-                helper.WriteLine(have);
-            }
+            CheckStates(have, resource, doStdout);
+        }
 
-            var want = ReadResource(resource);
-            Assert.Equal(want, have);
+        internal void CheckDfa<T>(RawDfa<T> dfa, string resource, bool doStdout = false)
+        {
+            var have = PrettyPrinter.Print(dfa);
+            CheckStates(have, resource, doStdout);
         }
 
         internal void CheckDfa<T>(DfaState<T> start, string resource, bool doStdout = false)
         {
             var have = PrettyPrinter.Print(start);
+            CheckStates(have, resource, doStdout);
+        }
+
+        private void CheckStates(string states, string resource, bool doStdout)
+        {
             if (doStdout)
             {
-                helper.WriteLine(have);
+                helper.WriteLine(states);
             }
 
-            var want = ReadResource(resource);
-            Assert.Equal(want, have);
+            var expected = ReadResource(resource);
+            states.Should().Be(expected);
         }
 
         internal void PrintDot<T>(Nfa<T> nfa, int start)
@@ -84,6 +89,11 @@ namespace CodeHive.DfaLex.Tests
         internal void PrintDot<T>(DfaState<T> start)
         {
             helper.WriteLine(PrettyPrinter.PrintDot(start));
+        }
+
+        internal void PrintDot<T>(RawDfa<T> rawDfa)
+        {
+            helper.WriteLine(PrettyPrinter.PrintDot(rawDfa));
         }
 
         protected string ReadResource(string resource)

--- a/dfalex/DfaFromNfa.cs
+++ b/dfalex/DfaFromNfa.cs
@@ -66,7 +66,7 @@ namespace CodeHive.DfaLex
         private void Build()
         {
             var nfaStateSet = new CompactIntSubset(nfa.NumStates);
-            var dfaStateTransitions = new List<NfaTransition>();
+            var dfaStateTransitions = new List<DfaTransition>();
             var transitionQ = new List<NfaTransition>(1000);
 
             //Create the DFA start states
@@ -167,7 +167,7 @@ namespace CodeHive.DfaLex
                         AddNfaStateAndEpsilonsToSubset(nfaStateSet, trans.State);
                     }
 
-                    dfaStateTransitions.Add(new NfaTransition(startc, endc, GetDfaState(nfaStateSet)));
+                    dfaStateTransitions.Add(new DfaTransition(startc, endc, GetDfaState(nfaStateSet)));
 
                     minc = (char) (endc + 1);
                     if (minc < endc)
@@ -196,11 +196,11 @@ namespace CodeHive.DfaLex
             {
                 var newNfaState = tempNfaClosureList.Dequeue();
                 nfa.ForStateEpsilons(newNfaState,
-                    src =>
+                    trans =>
                     {
-                        if (dest.Add(src))
+                        if (dest.Add(trans.State))
                         {
-                            tempNfaClosureList.Enqueue(src);
+                            tempNfaClosureList.Enqueue(trans.State);
                         }
                     });
             }
@@ -233,7 +233,7 @@ namespace CodeHive.DfaLex
             return dfaStateNum;
         }
 
-        private DfaStateInfo CreateStateInfo(IntListKey sig, List<NfaTransition> transitions)
+        private DfaStateInfo CreateStateInfo(IntListKey sig, List<DfaTransition> transitions)
         {
             //calculate the set of accepts
             tempResultSet.Clear();

--- a/dfalex/DfaMinimizer.cs
+++ b/dfalex/DfaMinimizer.cs
@@ -73,7 +73,7 @@ namespace CodeHive.DfaLex
         private void CreateNewStates()
         {
             minStates.Clear();
-            var tempTrans = new List<NfaTransition>();
+            var tempTrans = new List<DfaTransition>();
             foreach (var statenum in partitionOrderStates)
             {
                 var partnum = origOrderPartNums[statenum];
@@ -106,7 +106,7 @@ namespace CodeHive.DfaLex
                         endc = trans.LastChar;
                     }
 
-                    tempTrans.Add(new NfaTransition(startc, endc, dest));
+                    tempTrans.Add(new DfaTransition(startc, endc, dest));
                 }
 
                 minStates.Add(new DfaStateInfo(tempTrans, instate.GetAcceptSetIndex()));

--- a/dfalex/DfaStateInfo.cs
+++ b/dfalex/DfaStateInfo.cs
@@ -24,9 +24,9 @@ namespace CodeHive.DfaLex
     {
         private readonly int             acceptSetIndex;
         private readonly int             transitionCount;
-        private readonly NfaTransition[] transitionBuf;
+        private readonly DfaTransition[] transitionBuf;
 
-        internal DfaStateInfo(List<NfaTransition> transitions, int acceptSetIndex)
+        internal DfaStateInfo(List<DfaTransition> transitions, int acceptSetIndex)
         {
             this.acceptSetIndex = acceptSetIndex;
             transitionCount = transitions.Count;
@@ -43,12 +43,12 @@ namespace CodeHive.DfaLex
             return transitionCount;
         }
 
-        public NfaTransition GetTransition(int index)
+        public DfaTransition GetTransition(int index)
         {
             return transitionBuf[index];
         }
 
-        public void ForEachTransition(Action<NfaTransition> consumer)
+        public void ForEachTransition(Action<DfaTransition> consumer)
         {
             for (var i = 0; i < transitionCount; ++i)
             {

--- a/dfalex/DfaTransition.cs
+++ b/dfalex/DfaTransition.cs
@@ -24,17 +24,17 @@ namespace CodeHive.DfaLex
         /// <summary>
         /// The first character that triggers this transition.
         /// </summary>
-        public readonly char FirstChar;
+        public char FirstChar { get; }
 
         /// <summary>
         /// The last character that triggers this transition.
         /// </summary>
-        public readonly char LastChar;
+        public char LastChar { get; }
 
         /// <summary>
         /// The target state of this transition.
         /// </summary>
-        public readonly int State;
+        public int State { get; }
 
         /// <summary>
         /// Creates a new immutable NFA transtition.

--- a/dfalex/DfaTransition.cs
+++ b/dfalex/DfaTransition.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright 2015 Matthew Timmermans
- * Copyright 2019 Magne Rasmussen
+ * Copyright 2020 Magne Rasmussen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +17,9 @@
 namespace CodeHive.DfaLex
 {
     /// <summary>
-    /// A transition in a <see cref="Nfa{TResult}"/>
+    /// A transition between <see cref="DfaStateInfo"/>
     /// </summary>
-    public sealed class NfaTransition
+    internal sealed class DfaTransition
     {
         /// <summary>
         /// The first character that triggers this transition.
@@ -38,23 +37,16 @@ namespace CodeHive.DfaLex
         public readonly int State;
 
         /// <summary>
-        /// The priority of this transition.
-        /// </summary>
-        public NfaTransitionPriority Priority { get; }
-
-        /// <summary>
         /// Creates a new immutable NFA transtition.
         /// </summary>
         /// <param name="firstChar">The first character that triggers this transition.</param>
         /// <param name="lastChar">The last character that triggers this transition.</param>
         /// <param name="state">The target state of this transition.</param>
-        /// <param name="priority">The priority of this transition.</param>
-        public NfaTransition(char firstChar, char lastChar, int state, NfaTransitionPriority priority)
+        public DfaTransition(char firstChar, char lastChar, int state)
         {
             FirstChar = firstChar;
             LastChar = lastChar;
             State = state;
-            Priority = priority;
         }
 
         public override bool Equals(object obj)
@@ -64,9 +56,9 @@ namespace CodeHive.DfaLex
                 return true;
             }
 
-            if (obj is NfaTransition t)
+            if (obj is DfaTransition t)
             {
-                return FirstChar == t.FirstChar && LastChar == t.LastChar && State == t.State && Priority == t.Priority;
+                return FirstChar == t.FirstChar && LastChar == t.LastChar && State == t.State;
             }
 
             return false;
@@ -78,7 +70,6 @@ namespace CodeHive.DfaLex
             hash = (hash ^ FirstChar) * 16777619;
             hash = (hash ^ LastChar) * 16777619;
             hash = (hash ^ State) * 16777619;
-            hash = (hash ^ (int) Priority) * 16777619;
             return hash ^ (hash >> 16);
         }
     }

--- a/dfalex/IRegexContext.cs
+++ b/dfalex/IRegexContext.cs
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-using System;
-
 namespace CodeHive.DfaLex
 {
-    [Flags]
-    public enum RegexOptions
+    internal interface IRegexContext
     {
-        None       = 0x00000000,
-        IgnoreCase = 0x00000001, // "i"
+        bool Option(RegexOptions option);
 
-        [Obsolete("Will be removed in version 2.0.")]
-        Legacy     = 0x10000000
+        void ClrOption(RegexOptions option);
+
+        void SetOption(RegexOptions option);
     }
 }

--- a/dfalex/IRegexParserActions.cs
+++ b/dfalex/IRegexParserActions.cs
@@ -18,16 +18,16 @@ namespace CodeHive.DfaLex
 {
     internal interface IRegexParserActions<T> where T : class
     {
-        T Empty();
+        T Empty(IRegexContext ctx);
 
-        T Literal(CharRange range);
+        T Literal(IRegexContext ctx, CharRange range);
 
-        T Alternate(T p1, T p2);
+        T Alternate(IRegexContext ctx, T p1, T p2);
 
-        T Catenate(T p1, T p2);
+        T Catenate(IRegexContext ctx, T p1, T p2);
 
-        T Repeat(T p, int min = -1, int max = -1, bool greedy = true);
+        T Repeat(IRegexContext ctx, T p, int min = -1, int max = -1, bool lazy = false);
 
-        T Group(T p, int no);
+        T Group(IRegexContext ctx, T p, int no);
     }
 }

--- a/dfalex/IStringMatchEnumerator.cs
+++ b/dfalex/IStringMatchEnumerator.cs
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace CodeHive.DfaLex
@@ -32,14 +30,14 @@ namespace CodeHive.DfaLex
         /// Get the position of the start of the last match in the string.
         /// </summary>
         /// <returns>the index of the first character in the last match</returns>
-        /// <exception cref="InvalidOperationException">unless called after a valid call to <see cref="IEnumerator.MoveNext"/></exception>
+        /// <exception cref="System.InvalidOperationException">unless called after a valid call to <see cref="System.Collections.IEnumerator.MoveNext"/></exception>
         int MatchStartPosition { get; }
 
         /// <summary>
         /// Get the position of the end of the last match in the string.
         /// </summary>
         /// <returns>the index after the last character in the last match</returns>
-        /// <exception cref="InvalidOperationException">unless called after a valid call to <see cref="IEnumerator.MoveNext"/></exception>
+        /// <exception cref="System.InvalidOperationException">unless called after a valid call to <see cref="System.Collections.IEnumerator.MoveNext"/></exception>
         int MatchEndPosition { get; }
 
         /// <summary>
@@ -48,14 +46,14 @@ namespace CodeHive.DfaLex
         /// Note that a new string is allocated by the first call to this method for each match.
         /// </summary>
         /// <returns>the source portion of the source string corresponding to the last match</returns>
-        /// <exception cref="InvalidOperationException">unless called after a valid call to <see cref="IEnumerator.MoveNext"/></exception>
+        /// <exception cref="System.InvalidOperationException">unless called after a valid call to <see cref="System.Collections.IEnumerator.MoveNext"/></exception>
         string MatchValue { get; }
 
         /// <summary>
         /// Get the result of the last match.
         /// </summary>
-        /// <returns>the TResult returned by the last call to <see cref="IEnumerator.MoveNext"/></returns>
-        /// <exception cref="InvalidOperationException">unless called after a valid call to <see cref="IEnumerator.MoveNext"/></exception>
+        /// <returns>the TResult returned by the last call to <see cref="System.Collections.IEnumerator.MoveNext"/></returns>
+        /// <exception cref="System.InvalidOperationException">unless called after a valid call to <see cref="System.Collections.IEnumerator.MoveNext"/></exception>
         TResult MatchResult { get; }
 
         /// <summary>
@@ -63,12 +61,12 @@ namespace CodeHive.DfaLex
         ///
         /// The next match returned will be the one (if any) that starts at a position &gt;= pos
         ///
-        /// IMPORTANT:  If this method returns true, you must call <see cref="IEnumerator.MoveNext"/> to get the result
-        /// of the next match.  Until then calls to the the match accessor methods will continue to return information
-        /// from the previous call to <see cref="IEnumerator.MoveNext"/>.
+        /// IMPORTANT:  If this method returns true, you must call <see cref="System.Collections.IEnumerator.MoveNext"/>
+        /// to get the result of the next match.  Until then calls to the the match accessor methods will continue to
+        /// return information from the previous call to <see cref="System.Collections.IEnumerator.MoveNext"/>.
         /// </summary>
         /// <param name="pos">new position in the source string to search from</param>
-        /// <returns>true if there is a match after the given position.  The same value will be returned from <see cref="IEnumerator.MoveNext"/></returns>
+        /// <returns>true if there is a match after the given position.  The same value will be returned from <see cref="System.Collections.IEnumerator.MoveNext"/></returns>
         bool Reposition(int pos);
     }
 }

--- a/dfalex/Nfa.cs
+++ b/dfalex/Nfa.cs
@@ -95,6 +95,7 @@ namespace CodeHive.DfaLex
         /// </summary>
         /// <param name="from">The state to transition from</param>
         /// <param name="to">The state to transition to</param>
+        /// <param name="priority">The priority of this transition</param>
         public void AddEpsilon(int from, int to, NfaTransitionPriority priority = NfaTransitionPriority.Normal)
         {
             var list = stateEpsilons[from];

--- a/dfalex/Nfa.cs
+++ b/dfalex/Nfa.cs
@@ -30,9 +30,9 @@ namespace CodeHive.DfaLex
     public class Nfa<TResult>
     {
         private readonly List<List<NfaTransition>> stateTransitions = new List<List<NfaTransition>>();
-        private readonly List<List<int>>           stateEpsilons    = new List<List<int>>();
-        private readonly List<TResult>             stateAccepts     = new List<TResult>();
-        private readonly List<bool>                stateAccepting   = new List<bool>();
+        private readonly List<List<NfaEpsilon>>    stateEpsilons    = new List<List<NfaEpsilon>>();
+
+        private readonly List<(bool accepting, TResult accepts)> stateAccepts = new List<(bool, TResult)>();
 
         /// <summary>
         /// Get the number of states in the NFA
@@ -63,13 +63,11 @@ namespace CodeHive.DfaLex
         private int AddState(TResult accept, bool accepting)
         {
             var state = stateAccepts.Count;
-            stateAccepts.Add(accept);
-            stateAccepting.Add(accepting);
+            stateAccepts.Add((accepting, accept));
             stateTransitions.Add(null);
             stateEpsilons.Add(null);
             Debug.Assert(stateAccepts.Count == stateTransitions.Count);
             Debug.Assert(stateAccepts.Count == stateEpsilons.Count);
-            Debug.Assert(stateAccepts.Count == stateAccepting.Count);
             return state;
         }
 
@@ -89,7 +87,7 @@ namespace CodeHive.DfaLex
                 stateTransitions[from] = list;
             }
 
-            list.Add(new NfaTransition(firstChar, lastChar, to));
+            list.Add(new NfaTransition(firstChar, lastChar, to, NfaTransitionPriority.Normal));
         }
 
         /// <summary>
@@ -102,11 +100,11 @@ namespace CodeHive.DfaLex
             var list = stateEpsilons[from];
             if (list == null)
             {
-                list = new List<int>();
+                list = new List<NfaEpsilon>();
                 stateEpsilons[from] = list;
             }
 
-            list.Add(to);
+            list.Add(new NfaEpsilon(to, NfaTransitionPriority.Normal));
         }
 
         /// <summary>
@@ -116,7 +114,7 @@ namespace CodeHive.DfaLex
         /// <returns>True if the given state is accepting</returns>
         public bool IsAccepting(int state)
         {
-            return stateAccepting[state];
+            return stateAccepts[state].accepting;
         }
 
         /// <summary>
@@ -126,7 +124,7 @@ namespace CodeHive.DfaLex
         /// <returns>the result that was provided to <see cref="AddState()"/> when the state was created</returns>
         public TResult GetAccept(int state)
         {
-            return stateAccepts[state];
+            return stateAccepts[state].accepts;
         }
 
         /// <summary>
@@ -136,7 +134,7 @@ namespace CodeHive.DfaLex
         /// <returns>true if the state has any transitions or accepts</returns>
         public bool HasTransitionsOrAccepts(int state)
         {
-            return stateAccepting[state] || stateTransitions[state] != null;
+            return stateAccepts[state].accepting || stateTransitions[state] != null;
         }
 
         /// <summary>
@@ -144,10 +142,10 @@ namespace CodeHive.DfaLex
         /// </summary>
         /// <param name="state">the state number</param>
         /// <returns>An enumerable over all transitions out of the given state</returns>
-        public IEnumerable<int> GetStateEpsilons(int state)
+        public IEnumerable<NfaEpsilon> GetStateEpsilons(int state)
         {
             var list = stateEpsilons[state];
-            return list != null ? (IEnumerable<int>) list : new int[0];
+            return list != null ? (IEnumerable<NfaEpsilon>) list : new NfaEpsilon[0];
         }
 
         /// <summary>
@@ -182,11 +180,11 @@ namespace CodeHive.DfaLex
             for (var i = 0; i < reachable.Count; ++i)
             {
                 ForStateEpsilons(reachable[i],
-                                 num =>
+                                 trans =>
                                  {
-                                     if (checkSet.Add(num))
+                                     if (checkSet.Add(trans.State))
                                      {
-                                         reachable.Add(num);
+                                         reachable.Add(trans.State);
                                      }
                                  });
             }
@@ -211,19 +209,19 @@ namespace CodeHive.DfaLex
             foreach (var src in reachable)
             {
                 ForStateTransitions(src,
-                    trans =>
-                    {
-                        if (transSet.Add(trans))
-                        {
-                            AddTransition(newState, trans.State, trans.FirstChar, trans.LastChar);
-                        }
-                    });
+                                    trans =>
+                                    {
+                                        if (transSet.Add(trans))
+                                        {
+                                            AddTransition(newState, trans.State, trans.FirstChar, trans.LastChar);
+                                        }
+                                    });
             }
 
             return newState;
         }
 
-        internal void ForStateEpsilons(int state, Action<int> dest)
+        internal void ForStateEpsilons(int state, Action<NfaEpsilon> dest)
         {
             var list = stateEpsilons[state];
             list?.ForEach(dest);

--- a/dfalex/Nfa.cs
+++ b/dfalex/Nfa.cs
@@ -95,7 +95,7 @@ namespace CodeHive.DfaLex
         /// </summary>
         /// <param name="from">The state to transition from</param>
         /// <param name="to">The state to transition to</param>
-        public void AddEpsilon(int from, int to)
+        public void AddEpsilon(int from, int to, NfaTransitionPriority priority = NfaTransitionPriority.Normal)
         {
             var list = stateEpsilons[from];
             if (list == null)
@@ -104,7 +104,7 @@ namespace CodeHive.DfaLex
                 stateEpsilons[from] = list;
             }
 
-            list.Add(new NfaEpsilon(to, NfaTransitionPriority.Normal));
+            list.Add(new NfaEpsilon(to, priority));
         }
 
         /// <summary>

--- a/dfalex/NfaEpsilon.cs
+++ b/dfalex/NfaEpsilon.cs
@@ -1,6 +1,5 @@
 /*
- * Copyright 2015 Matthew Timmermans
- * Copyright 2019 Magne Rasmussen
+ * Copyright 2020 Magne Rasmussen
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,24 +17,14 @@
 namespace CodeHive.DfaLex
 {
     /// <summary>
-    /// A transition in a <see cref="Nfa{TResult}"/>
+    /// An epsilon transition in a <see cref="Nfa{TResult}"/>
     /// </summary>
-    public sealed class NfaTransition
+    public sealed class NfaEpsilon
     {
-        /// <summary>
-        /// The first character that triggers this transition.
-        /// </summary>
-        public readonly char FirstChar;
-
-        /// <summary>
-        /// The last character that triggers this transition.
-        /// </summary>
-        public readonly char LastChar;
-
         /// <summary>
         /// The target state of this transition.
         /// </summary>
-        public readonly int State;
+        public int State { get; }
 
         /// <summary>
         /// The priority of this transition.
@@ -45,14 +34,10 @@ namespace CodeHive.DfaLex
         /// <summary>
         /// Creates a new immutable NFA transtition.
         /// </summary>
-        /// <param name="firstChar">The first character that triggers this transition.</param>
-        /// <param name="lastChar">The last character that triggers this transition.</param>
         /// <param name="state">The target state of this transition.</param>
         /// <param name="priority">The priority of this transition.</param>
-        public NfaTransition(char firstChar, char lastChar, int state, NfaTransitionPriority priority)
+        public NfaEpsilon(int state, NfaTransitionPriority priority)
         {
-            FirstChar = firstChar;
-            LastChar = lastChar;
             State = state;
             Priority = priority;
         }
@@ -64,9 +49,9 @@ namespace CodeHive.DfaLex
                 return true;
             }
 
-            if (obj is NfaTransition t)
+            if (obj is NfaEpsilon t)
             {
-                return FirstChar == t.FirstChar && LastChar == t.LastChar && State == t.State && Priority == t.Priority;
+                return State == t.State && Priority == t.Priority;
             }
 
             return false;
@@ -75,8 +60,6 @@ namespace CodeHive.DfaLex
         public override int GetHashCode()
         {
             var hash = unchecked((int) 2166136261L);
-            hash = (hash ^ FirstChar) * 16777619;
-            hash = (hash ^ LastChar) * 16777619;
             hash = (hash ^ State) * 16777619;
             hash = (hash ^ (int) Priority) * 16777619;
             return hash ^ (hash >> 16);

--- a/dfalex/NfaTransition.cs
+++ b/dfalex/NfaTransition.cs
@@ -25,17 +25,17 @@ namespace CodeHive.DfaLex
         /// <summary>
         /// The first character that triggers this transition.
         /// </summary>
-        public readonly char FirstChar;
+        public char FirstChar { get; }
 
         /// <summary>
         /// The last character that triggers this transition.
         /// </summary>
-        public readonly char LastChar;
+        public char LastChar { get; }
 
         /// <summary>
         /// The target state of this transition.
         /// </summary>
-        public readonly int State;
+        public int State { get; }
 
         /// <summary>
         /// The priority of this transition.

--- a/dfalex/NfaTransitionPriority.cs
+++ b/dfalex/NfaTransitionPriority.cs
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Magne Rasmussen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace CodeHive.DfaLex
+{
+    public enum NfaTransitionPriority
+    {
+        Low,
+        Normal
+    }
+}

--- a/dfalex/Pattern.cs
+++ b/dfalex/Pattern.cs
@@ -101,10 +101,11 @@ namespace CodeHive.DfaLex
         /// </list>
         /// </summary>
         /// <param name="regex">regular expression string to parse</param>
+        /// <param name="options"><see cref="RegexOptions"/> that modify the interpretation of <paramref name="regex"/></param>
         /// <returns>a pattern that implements the regular expression</returns>
-        public static Pattern Regex(string regex)
+        public static Pattern Regex(string regex, RegexOptions options = RegexOptions.None)
         {
-            return Match(RegexParser.Parse(regex));
+            return Match(RegexParser.Parse(regex, options));
         }
 
         /// <summary>
@@ -113,10 +114,11 @@ namespace CodeHive.DfaLex
         /// See <see cref="Regex"/> for syntax information.
         /// </summary>
         /// <param name="regex">regular expression string to parse</param>
+        /// <param name="options"><see cref="RegexOptions"/> that modify the interpretation of <paramref name="regex"/></param>
         /// <returns>a pattern that implements the regular expression</returns>
-        public static Pattern RegexI(string regex)
+        public static Pattern RegexI(string regex, RegexOptions options = RegexOptions.None)
         {
-            return Match(RegexParser.Parse(regex, RegexOptions.IgnoreCase));
+            return Match(RegexParser.Parse(regex, options | RegexOptions.IgnoreCase));
         }
 
         /// <summary>

--- a/dfalex/Pattern.cs
+++ b/dfalex/Pattern.cs
@@ -150,6 +150,36 @@ namespace CodeHive.DfaLex
         }
 
         /// <summary>
+        /// Create a pattern that lazily matches one or more occurrences of a given pattern.
+        /// </summary>
+        /// <param name="pattern">given pattern</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern RepeatLazy(IMatchable pattern)
+        {
+            return new RepeatingPattern(pattern, true, true);
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches one or more occurrences of a particular string, case dependent
+        /// </summary>
+        /// <param name="str"> the string to match</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern RepeatLazy(string str)
+        {
+            return RepeatLazy(Match(str));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches one or more occurrences of a particular string, case independent
+        /// </summary>
+        /// <param name="str"> the string to match</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern RepeatLazyI(string str)
+        {
+            return RepeatLazy(MatchI(str));
+        }
+
+        /// <summary>
         /// Create a pattern that matches a given pattern or the empty string.
         /// </summary>
         /// <param name="pat">given pattern</param>
@@ -180,6 +210,36 @@ namespace CodeHive.DfaLex
         }
 
         /// <summary>
+        /// Create a pattern that lazily matches a given pattern or the empty string.
+        /// </summary>
+        /// <param name="pat">given pattern</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern MaybeLazy(IMatchable pat)
+        {
+            return new OptionalPattern(pat, true);
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches a particular string, or the empty string, case dependent
+        /// </summary>
+        /// <param name="str">the string to match</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern MaybeLazy(string str)
+        {
+            return MaybeLazy(Match(str));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches a particular string, or the empty string, case independent
+        /// </summary>
+        /// <param name="str">the string to match</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern MaybeLazyI(string str)
+        {
+            return MaybeLazy(MatchI(str));
+        }
+
+        /// <summary>
         /// Create a pattern that matches zero or more occurrences of a given pattern.
         /// </summary>
         /// <param name="pattern">given pattern</param>
@@ -207,6 +267,36 @@ namespace CodeHive.DfaLex
         public static Pattern MaybeRepeatI(string str)
         {
             return MaybeRepeat(MatchI(str));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches zero or more occurrences of a given pattern.
+        /// </summary>
+        /// <param name="pattern">given pattern</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern MaybeRepeatLazy(IMatchable pattern)
+        {
+            return new RepeatingPattern(pattern, false, true);
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches zero or more occurrences of a particular string, case dependent
+        /// </summary>
+        /// <param name="str">the string to match</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern MaybeRepeatLazy(string str)
+        {
+            return MaybeRepeatLazy(Match(str));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches zero or more occurrences of a particular string, case independent
+        /// </summary>
+        /// <param name="str">the string to match</param>
+        /// <returns>the new pattern</returns>
+        public static Pattern MaybeRepeatLazyI(string str)
+        {
+            return MaybeRepeatLazy(MatchI(str));
         }
 
         /// <summary>
@@ -360,6 +450,36 @@ namespace CodeHive.DfaLex
         }
 
         /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, followed by one or more occurrences of a given pattern.
+        /// </summary>
+        /// <param name="pattern">the given pattern</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenRepeatLazy(IMatchable pattern)
+        {
+            return Then(RepeatLazy(pattern));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, followed by one or more occurrences of a given string, case dependent.
+        /// </summary>
+        /// <param name="str">the given string</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenRepeatLazy(string str)
+        {
+            return Then(RepeatLazy(str));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, followed by one or more occurrences of a given string, case independent.
+        /// </summary>
+        /// <param name="str">the given string</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenRepeatLazyI(string str)
+        {
+            return Then(RepeatLazyI(str));
+        }
+
+        /// <summary>
         /// Create a pattern that matches strings from this pattern, maybe followed by a match of the given pattern.
         /// </summary>
         /// <param name="pattern">the given pattern</param>
@@ -390,6 +510,36 @@ namespace CodeHive.DfaLex
         }
 
         /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, maybe followed by a match of the given pattern.
+        /// </summary>
+        /// <param name="pattern">the given pattern</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenMaybeLazy(IMatchable pattern)
+        {
+            return Then(MaybeLazy(pattern));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, maybe followed by a match of the given string, case dependent.
+        /// </summary>
+        /// <param name="str">the given string</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenMaybeLazy(string str)
+        {
+            return Then(MaybeLazy(str));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, maybe followed by a match of the given string, case independent.
+        /// </summary>
+        /// <param name="str">the given string</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenMaybeLazyI(string str)
+        {
+            return Then(MaybeLazyI(str));
+        }
+
+        /// <summary>
         /// Create a pattern that matches strings from this pattern, followed by zero or more occurrences of the given pattern.
         /// </summary>
         /// <param name="pattern">the given pattern</param>
@@ -417,6 +567,36 @@ namespace CodeHive.DfaLex
         public Pattern ThenMaybeRepeatI(string str)
         {
             return Then(MaybeRepeatI(str));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, followed by zero or more occurrences of the given pattern.
+        /// </summary>
+        /// <param name="pattern">the given pattern</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenMaybeRepeatLazy(IMatchable pattern)
+        {
+            return Then(MaybeRepeatLazy(pattern));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, followed by zero or more occurrences of the given string, case dependent.
+        /// </summary>
+        /// <param name="str">the given string</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenMaybeRepeatLazy(string str)
+        {
+            return Then(MaybeRepeatLazy(str));
+        }
+
+        /// <summary>
+        /// Create a pattern that lazily matches strings from this pattern, followed by zero or more occurrences of the given string, case dependent.
+        /// </summary>
+        /// <param name="str">the given string</param>
+        /// <returns>the new pattern</returns>
+        public Pattern ThenMaybeRepeatLazyI(string str)
+        {
+            return Then(MaybeRepeatLazyI(str));
         }
 
         public abstract int AddToNfa<TResult>(Nfa<TResult> nfa, int targetState);
@@ -646,27 +826,30 @@ namespace CodeHive.DfaLex
         {
             private readonly IMatchable pattern;
             private readonly bool       needAtLeastOne;
+            private readonly bool       lazy;
 
-            public RepeatingPattern(IMatchable pattern, bool needAtLeastOne)
+            public RepeatingPattern(IMatchable pattern, bool needAtLeastOne, bool lazy = false)
             {
                 this.pattern = pattern;
                 this.needAtLeastOne = needAtLeastOne;
+                this.lazy = lazy;
             }
 
             public override int AddToNfa<TResult>(Nfa<TResult> nfa, int targetState)
             {
                 var repState = nfa.AddState();
-                nfa.AddEpsilon(repState, targetState, NfaTransitionPriority.Low);
+                nfa.AddEpsilon(repState, targetState, lazy ? NfaTransitionPriority.Normal : NfaTransitionPriority.Low);
                 var startState = pattern.AddToNfa(nfa, repState);
-                nfa.AddEpsilon(repState, startState);
                 if (needAtLeastOne || pattern.MatchesEmpty)
                 {
+                    nfa.AddEpsilon(repState, startState, lazy ? NfaTransitionPriority.Low : NfaTransitionPriority.Normal);
                     return startState;
                 }
 
                 var skipState = nfa.AddState();
-                nfa.AddEpsilon(skipState, targetState, NfaTransitionPriority.Low);
-                nfa.AddEpsilon(skipState, startState);
+                nfa.AddEpsilon(repState, skipState);
+                nfa.AddEpsilon(skipState, targetState, lazy ? NfaTransitionPriority.Normal : NfaTransitionPriority.Low);
+                nfa.AddEpsilon(skipState, startState, lazy ? NfaTransitionPriority.Low : NfaTransitionPriority.Normal);
                 return skipState;
             }
 
@@ -687,7 +870,7 @@ namespace CodeHive.DfaLex
                     return this;
                 }
 
-                return new RepeatingPattern(patternReversed, needAtLeastOne);
+                return new RepeatingPattern(patternReversed, needAtLeastOne, lazy);
             }
         }
 
@@ -695,10 +878,12 @@ namespace CodeHive.DfaLex
         private class OptionalPattern : Pattern
         {
             private readonly IMatchable pattern;
+            private readonly bool       lazy;
 
-            public OptionalPattern(IMatchable pattern)
+            public OptionalPattern(IMatchable pattern, bool lazy = false)
             {
                 this.pattern = pattern;
+                this.lazy = lazy;
             }
 
             public override int AddToNfa<TResult>(Nfa<TResult> nfa, int targetState)
@@ -710,8 +895,8 @@ namespace CodeHive.DfaLex
                 }
 
                 var skipState = nfa.AddState();
-                nfa.AddEpsilon(skipState, targetState, NfaTransitionPriority.Low);
-                nfa.AddEpsilon(skipState, startState);
+                nfa.AddEpsilon(skipState, targetState, lazy ? NfaTransitionPriority.Normal : NfaTransitionPriority.Low);
+                nfa.AddEpsilon(skipState, startState,  lazy ? NfaTransitionPriority.Low : NfaTransitionPriority.Normal);
                 return skipState;
             }
 
@@ -732,7 +917,7 @@ namespace CodeHive.DfaLex
                     return this;
                 }
 
-                return new OptionalPattern(revpat);
+                return new OptionalPattern(revpat, lazy);
             }
         }
 
@@ -778,11 +963,11 @@ namespace CodeHive.DfaLex
                 var pattern = new UnionPattern(newChoices);
 
                 var endState = nfa.AddState();
-                nfa.AddEpsilon(endState, targetState, NfaTransitionPriority.Low);
+                nfa.AddEpsilon(endState,   targetState, NfaTransitionPriority.Low);
                 nfa.AddEpsilon(startState, choices[choices.Length - 1].AddToNfa(nfa, endState));
 
                 endState = nfa.AddState();
-                nfa.AddEpsilon(endState, targetState);
+                nfa.AddEpsilon(endState,   targetState);
                 nfa.AddEpsilon(startState, pattern.AddToNfa(nfa, endState));
 
                 return startState;

--- a/dfalex/RawDfa.cs
+++ b/dfalex/RawDfa.cs
@@ -43,7 +43,7 @@ namespace CodeHive.DfaLex
 
         public List<DfaStateInfo> States => dfaStates;
 
-        public List<(bool, TResult)> AcceptSets => acceptSets;
+        public List<(bool accept, TResult match)> AcceptSets => acceptSets;
 
         public int[] StartStates => startStates;
     }

--- a/dfalex/RegexParser.cs
+++ b/dfalex/RegexParser.cs
@@ -367,8 +367,8 @@ namespace CodeHive.DfaLex
             bld.AddPattern(sPos.Then("S|C"),
                            (parser, actions) =>
                            {
-                               var p1 = parser.Pop(2);
-                               var p2 = parser.Pop(1);
+                               var p2 = parser.Pop(2);
+                               var p1 = parser.Pop(1);
                                parser.Push("S", actions.Alternate(p1, p2));
                            });
             var cPos = sPos.ThenMaybe("S|");

--- a/dfalex/RegexParser.cs
+++ b/dfalex/RegexParser.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using static CodeHive.DfaLex.RegexParserConstants;
@@ -26,7 +27,7 @@ namespace CodeHive.DfaLex
     /// <summary>
     /// Parses regular expression into <see cref="IMatchable"/> implementations.
     ///
-    /// One would normally use <see cref="Pattern.Regex(string)"/> or <see cref="Pattern.RegexI(string)"/> instead of using
+    /// One would normally use <see cref="Pattern.Regex"/> or <see cref="Pattern.RegexI"/> instead of using
     /// this class directly.
     ///
     /// Syntax supported include:
@@ -72,36 +73,53 @@ namespace CodeHive.DfaLex
         /// <param name="regex">a string containing the expression to parse</param>
         /// <param name="caseIndependent">true to make it case independent</param>
         /// <returns>a <see cref="IMatchable"/> that implements the regular expression</returns>
-        [Obsolete("Use RegexParser.Parse(regex, RegexOptions.IgnoreCase) instead.")]
+        [Obsolete("Use RegexParser.Parse(regex, RegexOptions.IgnoreCase) instead. Will be removed in version 2.0")]
         public static IMatchable Parse(string regex, bool caseIndependent)
         {
-            return Parse(regex, caseIndependent ? RegexOptions.IgnoreCase : RegexOptions.None);
+            var options = caseIndependent ? RegexOptions.IgnoreCase : RegexOptions.None;
+            return Parse(regex, options);
         }
 
         private RegexParser(string str, RegexOptions options)
             : base(Actions, str, options)
         { }
 
+
         private sealed class MatchableRegexParserActions : IRegexParserActions<IMatchable>
         {
-            public IMatchable Empty() => Pattern.Empty;
+            public IMatchable Empty(IRegexContext ctx) => Pattern.Empty;
 
-            public IMatchable Literal(CharRange range) => range;
+            public IMatchable Literal(IRegexContext ctx, CharRange range) => range;
 
-            public IMatchable Alternate(IMatchable p1, IMatchable p2) => Pattern.AnyOf(p1, p2);
+            public IMatchable Alternate(IRegexContext ctx, IMatchable p1, IMatchable p2) => Pattern.AnyOf(p1, p2);
 
-            public IMatchable Catenate(IMatchable p1, IMatchable p2) => Pattern.Match(p1).Then(p2);
+            public IMatchable Catenate(IRegexContext ctx, IMatchable p1, IMatchable p2) => Pattern.Match(p1).Then(p2);
 
-            public IMatchable Repeat(IMatchable p, int min = -1, int max = -1, bool greedy = true)
+            public IMatchable Repeat(IRegexContext ctx, IMatchable p, int min = -1, int max = -1, bool lazy = false)
             {
+#pragma warning disable 618
+                if (ctx.Option(RegexOptions.Legacy))
+#pragma warning restore 618
+                {
+                    switch (min, max)
+                    {
+                        case (0, 1):
+                            return Pattern.Maybe(p);
+                        case (0, -1):
+                            return Pattern.MaybeRepeat(p);
+                        case (1, -1):
+                            return lazy ? Pattern.MaybeRepeat(p) : Pattern.Repeat(p);
+                    }
+                }
+
                 switch (min, max)
                 {
                     case (0, 1):
-                        return Pattern.Maybe(p);
+                        return lazy ? Pattern.MaybeLazy(p) : Pattern.Maybe(p);
                     case (0, -1):
-                        return Pattern.MaybeRepeat(p);
+                        return lazy ? Pattern.MaybeRepeatLazy(p) : Pattern.MaybeRepeat(p);
                     case (1, -1):
-                        return Pattern.Repeat(p);
+                        return lazy ? Pattern.RepeatLazy(p) : Pattern.Repeat(p);
                     default:
                         var strMin = min == -1 ? string.Empty : min.ToString();
                         var strMax = max == -1 ? string.Empty : max.ToString();
@@ -109,7 +127,7 @@ namespace CodeHive.DfaLex
                 }
             }
 
-            public IMatchable Group(IMatchable p, int no) => p;
+            public IMatchable Group(IRegexContext ctx, IMatchable p, int no) => p;
         }
     }
 
@@ -129,12 +147,11 @@ namespace CodeHive.DfaLex
 
     internal class RegexParser<T> where T : class
     {
-        // ReSharper disable once InconsistentNaming
-        private static readonly DfaState<Action> DFA = BuildParserDfa();
+        private static readonly DfaState<Action> Dfa = BuildParserDfa();
 
         private readonly IRegexParserActions<T>  actions;
+        private readonly IRegexContext           context;
         private readonly string                  str;
-        private readonly bool                    caseI;
         private          int                     readPos;
         private readonly CharRange.Builder       charBuilder = CharRange.CreateBuilder();
         private          char                    cprev;
@@ -149,7 +166,7 @@ namespace CodeHive.DfaLex
             this.actions = actions;
             this.str = str;
 
-            caseI = (options & RegexOptions.IgnoreCase) == RegexOptions.IgnoreCase;
+            context = new RegexContext(options);
         }
 
         protected T Parse()
@@ -159,7 +176,7 @@ namespace CodeHive.DfaLex
             symStack.Clear();
             nparen = 0;
             readPos = 0;
-            stateStack.Push(DFA);
+            stateStack.Push(Dfa);
             var srclen = str.Length;
             var maxpos = 0;
             while (true)
@@ -208,7 +225,7 @@ namespace CodeHive.DfaLex
                     break;
                 }
 
-                action(this, actions);
+                action(this, actions, context);
             }
 
             if (!"S".Equals(symStack.ToString()))
@@ -216,7 +233,7 @@ namespace CodeHive.DfaLex
                 throw new ArgumentException($"Invald regular expression: \"{str}\" has error at position {maxpos}");
             }
 
-            System.Diagnostics.Debug.Assert(valStack.Count == 1);
+            Debug.Assert(valStack.Count == 1);
             return valStack.Pop();
         }
 
@@ -362,44 +379,49 @@ namespace CodeHive.DfaLex
             var sPos = Pattern.MaybeRepeat(Pattern.MaybeRepeat(CharRange.AnyOf("SCA|")).Then("("));
 
             // S: C | S '|' C
-            bld.AddPattern(sPos.Then("C"),   (parser, _) => parser.Push("S", parser.Pop(1)));
-            bld.AddPattern(sPos.Then("S:|"), (parser, _) => parser.Push("|", null));
+            bld.AddPattern(sPos.Then("C"),   (parser, _, __) => parser.Push("S", parser.Pop(1)));
+            bld.AddPattern(sPos.Then("S:|"), (parser, _, __) => parser.Push("|", null));
             bld.AddPattern(sPos.Then("S|C"),
-                           (parser, actions) =>
+                           (parser, actions, ctx) =>
                            {
                                var p2 = parser.Pop(2);
                                var p1 = parser.Pop(1);
-                               parser.Push("S", actions.Alternate(p1, p2));
+                               parser.Push("S", actions.Alternate(ctx, p1, p2));
                            });
             var cPos = sPos.ThenMaybe("S|");
 
             // C: e | C A
-            bld.AddPattern(cPos, (parser, actions) => parser.Push("C", actions.Empty()));
+            bld.AddPattern(cPos, (parser, actions, ctx) => parser.Push("C", actions.Empty(ctx)));
             bld.AddPattern(cPos.Then("CA"),
-                           (parser, actions) =>
+                           (parser, actions, ctx) =>
                            {
                                var p2 = parser.Pop(1);
                                var p1 = parser.Pop(1);
-                               parser.Push("C", actions.Catenate(p1, p2));
+                               parser.Push("C", actions.Catenate(ctx, p1, p2));
                            });
             var aPos = cPos.Then("C");
 
             //A: A? | A+ | A*
-            bld.AddPattern(aPos.Then("A:?"), (parser, actions) => parser.Push("A", actions.Repeat(parser.Pop(1), 0, 1)));
-            bld.AddPattern(aPos.Then("A:+"), (parser, actions) => parser.Push("A", actions.Repeat(parser.Pop(1), 1)));
-            bld.AddPattern(aPos.Then("A:*"), (parser, actions) => parser.Push("A", actions.Repeat(parser.Pop(1), 0)));
+            bld.AddPattern(aPos.Then("A:?"), (parser, actions, ctx) => parser.Push("A", actions.Repeat(ctx, parser.Pop(1), 0, 1)));
+            bld.AddPattern(aPos.Then("A:+"), (parser, actions, ctx) => parser.Push("A", actions.Repeat(ctx, parser.Pop(1), 1)));
+            bld.AddPattern(aPos.Then("A:*"), (parser, actions, ctx) => parser.Push("A", actions.Repeat(ctx, parser.Pop(1), 0)));
+
+            // A: A?? | A+? | A*?
+            bld.AddPattern(aPos.Then("A:??"), (parser, actions, ctx) => parser.Push("A", actions.Repeat(ctx, parser.Pop(1), 0, 1, true)));
+            bld.AddPattern(aPos.Then("A:+?"), (parser, actions, ctx) => parser.Push("A", actions.Repeat(ctx, parser.Pop(1), 1, lazy: true)));
+            bld.AddPattern(aPos.Then("A:*?"), (parser, actions, ctx) => parser.Push("A", actions.Repeat(ctx, parser.Pop(1), 0, lazy: true)));
 
             //A: GROUP
-            bld.AddPattern(aPos.Then(":("),   (parser, actions) => parser.Push("(", null));
-            bld.AddPattern(aPos.Then("(S:)"), (parser, actions) => parser.Push("A", actions.Group(parser.Pop(2), ++parser.nparen)));
+            bld.AddPattern(aPos.Then(":("),   (parser, actions, ctx) => parser.Push("(", null));
+            bld.AddPattern(aPos.Then("(S:)"), (parser, actions, ctx) => parser.Push("A", actions.Group(ctx, parser.Pop(2), ++parser.nparen)));
 
             //A: literal | .
             bld.AddPattern(aPos.Then(":").Then(CharRange.CreateBuilder().AddChars(".()[]+*?|\\").Invert().Build()),
-                           (parser, actions) =>
+                           (parser, actions, ctx) =>
                            {
                                CharRange range;
                                var c = parser.LastChar();
-                               if (!parser.caseI)
+                               if (!ctx.Option(RegexOptions.IgnoreCase))
                                {
                                    range = CharRange.Single(c);
                                }
@@ -417,9 +439,9 @@ namespace CodeHive.DfaLex
                                    }
                                }
 
-                               parser.Push("A", actions.Literal(range));
+                               parser.Push("A", actions.Literal(ctx, range));
                            });
-            bld.AddPattern(aPos.Then(":."), (parser, actions) => parser.Push("A", actions.Literal(CharRange.All)));
+            bld.AddPattern(aPos.Then(":."), (parser, actions, ctx) => parser.Push("A", actions.Literal(ctx, CharRange.All)));
 
             var charEscape = Pattern.Match(":\\").Then(Pattern.AnyOf(
                                                                      Pattern.Match("x").Then(CharRange.HexDigits).Then(CharRange.HexDigits),
@@ -429,63 +451,63 @@ namespace CodeHive.DfaLex
                                                                      CharRange.CreateBuilder().AddChars("xucdDwWsS").Invert().Build()));
             var classEscape = Pattern.Match(":\\").Then(Pattern.AnyCharIn("dDsSwW"));
 
-            bld.AddPattern(aPos.Then(charEscape),  (parser, actions) => parser.Push("A", actions.Literal(CharRange.Single(parser.ParseCharEscape()))));
-            bld.AddPattern(aPos.Then(classEscape), (parser, actions) => parser.Push("A", actions.Literal(parser.ParseClassEscape())));
+            bld.AddPattern(aPos.Then(charEscape),  (parser, actions, ctx) => parser.Push("A", actions.Literal(ctx, CharRange.Single(parser.ParseCharEscape()))));
+            bld.AddPattern(aPos.Then(classEscape), (parser, actions, ctx) => parser.Push("A", actions.Literal(ctx, parser.ParseClassEscape())));
 
             //A: [R] | [^R]
             bld.AddPattern(aPos.Then(":[^"),
-                           (parser, _) =>
+                           (parser, _, __) =>
                            {
                                parser.charBuilder.Clear();
                                parser.Push("[^", null);
                            });
             bld.AddPattern(aPos.Then(":["),
-                           (parser, _) =>
+                           (parser, _, __) =>
                            {
                                parser.charBuilder.Clear();
                                parser.Push("[", null);
                            });
             bld.AddPattern(aPos.Then("[R:]"),
-                           (parser, actions) =>
+                           (parser, actions, ctx) =>
                            {
                                parser.Pop(2);
-                               if (parser.caseI)
+                               if (ctx.Option(RegexOptions.IgnoreCase))
                                {
                                    parser.charBuilder.ExpandCases();
                                }
 
-                               parser.Push("A", actions.Literal(parser.charBuilder.Build()));
+                               parser.Push("A", actions.Literal(ctx, parser.charBuilder.Build()));
                            });
             bld.AddPattern(aPos.Then("[^R:]"),
-                           (parser, actions) =>
+                           (parser, actions, ctx) =>
                            {
                                parser.Pop(3);
-                               if (parser.caseI)
+                               if (ctx.Option(RegexOptions.IgnoreCase))
                                {
                                    parser.charBuilder.ExpandCases();
                                }
 
-                               parser.Push("A", actions.Literal(parser.charBuilder.Invert().Build()));
+                               parser.Push("A", actions.Literal(ctx, parser.charBuilder.Invert().Build()));
                            });
             var rPos = aPos.Then(Pattern.AnyOf("[^", "["));
 
             //R: e | R classEscape | R c | R c - c
-            bld.AddPattern(rPos, (parser, _) => parser.Push("R", null));
+            bld.AddPattern(rPos, (parser, _, __) => parser.Push("R", null));
             bld.AddPattern(rPos.Then("R").Then(classEscape),
-                           (parser, _) =>
+                           (parser, _, __) =>
                            {
                                parser.charBuilder.AddRange(parser.ParseClassEscape());
                                parser.Pop(0);
                            });
             bld.AddPattern(rPos.Then("Rc"),
-                           (parser, _) =>
+                           (parser, _, __) =>
                            {
                                parser.Pop(1);
                                parser.charBuilder.AddRange(parser.clast, parser.clast);
                            });
-            bld.AddPattern(rPos.Then("Rc:-"), (parser, _) => parser.Push("-", null));
+            bld.AddPattern(rPos.Then("Rc:-"), (parser, _, ctx) => parser.Push("-", null));
             bld.AddPattern(rPos.Then("Rc-c"),
-                           (parser, _) =>
+                           (parser, _, __) =>
                            {
                                parser.Pop(3);
                                if (parser.clast < parser.cprev)
@@ -501,14 +523,14 @@ namespace CodeHive.DfaLex
 
             //class chars
             bld.AddPattern(cpos.Then(":").Then(CharRange.CreateBuilder().AddChars("-[]\\").Invert().Build()),
-                           (parser, _) =>
+                           (parser, _, __) =>
                            {
                                parser.cprev = parser.clast;
                                parser.clast = parser.LastChar();
                                parser.Push("c", null);
                            });
             bld.AddPattern(cpos.Then(charEscape),
-                           (parser, _) =>
+                           (parser, _, __) =>
                            {
                                parser.cprev = parser.clast;
                                parser.clast = parser.ParseCharEscape();
@@ -518,6 +540,21 @@ namespace CodeHive.DfaLex
             return bld.Build(null);
         }
 
-        private delegate void Action(RegexParser<T> parser, IRegexParserActions<T> actions);
+        private delegate void Action(RegexParser<T> parser, IRegexParserActions<T> actions, IRegexContext ctx);
+
+        private sealed class RegexContext : IRegexContext
+        {
+            private RegexOptions options;
+
+            public RegexContext(RegexOptions options)
+            {
+                this.options = options;
+            }
+
+            public bool Option(RegexOptions option) => (options & option) == option;
+
+            public void ClrOption(RegexOptions option) => options &= ~option;
+            public void SetOption(RegexOptions option) => options |= option;
+        }
     }
 }


### PR DESCRIPTION
This actually creates a breaking change in then parsing of the regular expressions. If you use two consecutive quantifiers, and the last one is `?`, the new parser will not give the same result. You may enable the old parsing with `Pattern.Regex("...", RegexOptions.Legacy)`.

Please note that RegexOption.Legacy is obsolete, and will be removed in version 2.0.

Closes #6, closes #7.